### PR TITLE
NEB-1737 Resolved issue on the string representation of a Rule when BYSETOPS is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Indonesian translations. ([#505](https://github.com/seejohnrun/ice_cube/pull/505)) by [@achmiral](https://github.com/achmiral)
-- Support for BYSETPOS, including tests, and minor hash bug fixes
+- Support for BYSETPOS, including tests, and fixes for minor bugs (ie. Rule.from_hash, and Rule.to_s)
 
 ### Changed
 - Removed use of `delegate` method added in [66f1d797](https://github.com/ice-cube-ruby/ice_cube/commit/66f1d797092734563bfabd2132c024c7d087f683) , reverting to previous implementation. ([#522](https://github.com/ice-cube-ruby/ice_cube/pull/522))  by [@pacso](https://github.com/pacso)

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -84,7 +84,7 @@ module IceCube
           apply_validation(rule, name, args)
         end
 
-        if hash[:by_set_pos].present?
+        unless hash[:by_set_pos].nil?
           rule.send(:by_set_pos, hash[:by_set_pos])
         end
 

--- a/lib/ice_cube/validations/monthly_by_set_pos.rb
+++ b/lib/ice_cube/validations/monthly_by_set_pos.rb
@@ -56,7 +56,9 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.piece(:by_set_pos) << by_set_pos
+        # returning empty string for BYSETPOS
+        # as this field is already represented by the BYMONTHDAY
+        ""
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/weekly_by_set_pos.rb
+++ b/lib/ice_cube/validations/weekly_by_set_pos.rb
@@ -73,7 +73,9 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.piece(:by_set_pos) << by_set_pos
+        # returning empty string for BYSETPOS
+        # as this field is already represented by the BYDAY
+        ""
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/yearly_by_set_pos.rb
+++ b/lib/ice_cube/validations/yearly_by_set_pos.rb
@@ -56,7 +56,9 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.piece(:by_set_pos) << by_set_pos
+        # returning empty string for BYSETPOS
+        # as this field is already represented by the BYYEARDAY
+        ""
       end
 
       def build_hash(builder)

--- a/spec/examples/from_ical_spec.rb
+++ b/spec/examples/from_ical_spec.rb
@@ -103,6 +103,21 @@ module IceCube
       }.to raise_error(/Expecting number in \[-366, -1\] or \[1, 366\]/)
     end
 
+    it "should be able to return text correctly while using BYYEARDAY / BYSETPOS param" do
+      rule = ::IceCube::Rule.from_ical "FREQ=YEARLY;COUNT=12;BYYEARDAY=28,29,30;BYSETPOS=-1"
+      expect(rule.to_s).to eq("Yearly 12 times on the 28th, 29th, and 30th days of the year")
+    end
+
+    it "should be able to return text correctly while using BYMONTHDAY / BYSETPOS param" do
+      rule = ::IceCube::Rule.from_ical "FREQ=MONTHLY;COUNT=12;BYMONTHDAY=28,29,30;BYSETPOS=-1"
+      expect(rule.to_s).to eq("Monthly 12 times on the 28th, 29th, and 30th days of the month")
+    end
+
+    it "should be able to return text correctly while using BYDAY / BYSETPOS param" do
+      rule = ::IceCube::Rule.from_ical "FREQ=WEEKLY;COUNT=12;BYDAY=MO,TU;BYSETPOS=-1"
+      expect(rule.to_s).to eq("Weekly 12 times on Mondays and Tuesdays")
+    end
+
     it "should return no occurrences after daily interval with count is over" do
       schedule = IceCube::Schedule.new(Time.now)
       schedule.add_recurrence_rule(IceCube::Rule.from_ical("FREQ=DAILY;COUNT=5"))


### PR DESCRIPTION
*What*
Resolved issue on the string representation of a Rule when BYSETOPS is present

*Why*
When getting the string representation of a rule (ie. `rule.to_s`), the text was showing the actual value of the BYSETOPS. For example:

- Rule: `FREQ=WEEKLY;COUNT=12;BYDAY=MO,TU;BYSETPOS=-1`
- to_s: `Weekly 12 times on Mondays and Tuesdays [-1]`

