### PR TITLE
Add BYSETPOS Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- some validation for ensuring BYSETPOS rule is used in conjunction with another BY* part rule. ([ignitionapp/ice_cube #5](https://github.com/ignitionapp/ice_cube/pull/5))
+
+### Added
 - Indonesian translations. ([#505](https://github.com/seejohnrun/ice_cube/pull/505)) by [@achmiral](https://github.com/achmiral)
 - Support for BYSETPOS, including tests, and fixes for minor bugs (ie. Rule.from_hash, and Rule.to_s)
 

--- a/lib/ice_cube/flexible_hash.rb
+++ b/lib/ice_cube/flexible_hash.rb
@@ -25,9 +25,9 @@ module IceCube
 
     def _match_key(key)
       return key if __getobj__.has_key? key
-      if Symbol == key.class
+      if key.class == Symbol
         __getobj__.keys.detect { |k| return k if k == key.to_s }
-      elsif String == key.class
+      elsif key.class == String
         __getobj__.keys.detect { |k| return k if k.to_s == key }
       end
       key

--- a/lib/ice_cube/flexible_hash.rb
+++ b/lib/ice_cube/flexible_hash.rb
@@ -25,9 +25,9 @@ module IceCube
 
     def _match_key(key)
       return key if __getobj__.has_key? key
-      if key.class == Symbol
+      if key.instance_of?(Symbol)
         __getobj__.keys.detect { |k| return k if k == key.to_s }
-      elsif key.class == String
+      elsif key.instance_of(String)
         __getobj__.keys.detect { |k| return k if k.to_s == key }
       end
       key

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -111,9 +111,9 @@ module IceCube
         ]
 
         if !!validations[:by_set_pos]
-          return by_parts.any? { |part| validations[part] }
+          by_parts.any? { |part| validations[part] }
         else
-          return true
+          true
         end
       end
 

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -84,11 +84,37 @@ module IceCube
           apply_validation(rule, name, args)
         end
 
+        unless hash[:validations][:by_set_pos].nil?
+          unless validate_by_set_pos_by_parts(rule, hash[:validations])
+            raise ArgumentError, "BYSETPOS must be used in conjuction with another BY* rule part"
+          end
+        end
+
         unless hash[:by_set_pos].nil?
           rule.send(:by_set_pos, hash[:by_set_pos])
         end
 
         rule
+      end
+
+      def validate_by_set_pos_by_parts(rule, validations)
+        by_parts = [
+          :month_of_year,
+          :week_of_year,
+          :day_of_year,
+          :day_of_month,
+          :day,
+          :day_of_week,
+          :hour_of_day,
+          :minute_of_hour,
+          :second_of_minute,
+        ]
+
+        if !!validations[:by_set_pos]
+          return by_parts.any? { |part| validations[part] }
+        else
+          return true
+        end
       end
 
       private

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -107,7 +107,7 @@ module IceCube
           :day_of_week,
           :hour_of_day,
           :minute_of_hour,
-          :second_of_minute,
+          :second_of_minute
         ]
 
         if !!validations[:by_set_pos]

--- a/spec/examples/from_ical_spec.rb
+++ b/spec/examples/from_ical_spec.rb
@@ -410,6 +410,11 @@ module IceCube
         str = "FREQ=DAILY;FAKE=23"
         expect { Rule.from_ical(str) }.to raise_error(ArgumentError, "Invalid rule validation type: FAKE")
       end
+
+      it "should raise ArgumentError when parsing BYSETPOS without another BY* part rule" do
+        str = "FREQ=MONTHLY;BYSETPOS=-1"
+        expect { Rule.from_ical(str) }.to raise_error(ArgumentError, "BYSETPOS must be used in conjuction with another BY* rule part")
+      end
     end
 
     describe "multiple rules" do
@@ -440,6 +445,14 @@ module IceCube
 
       describe "incomplete rule" do
         let(:ical_str) { "RRULE:FREQ" }
+        it_behaves_like "an invalid ical string"
+      end
+
+      describe "BYSETPOS without another BY* part rule" do
+        # str = "FREQ=MONTHLY;BYSETPOS=-1"
+        # expect { Rule.from_ical(str) }.to raise_error(ArgumentError, "BYSETPOS must be used in conjuction with another BY* rule part")
+
+        let(:ical_str) { "RRULE:FREQ=MONTHLY;BYSETPOS=-1" }
         it_behaves_like "an invalid ical string"
       end
 

--- a/spec/examples/from_ical_spec.rb
+++ b/spec/examples/from_ical_spec.rb
@@ -449,9 +449,6 @@ module IceCube
       end
 
       describe "BYSETPOS without another BY* part rule" do
-        # str = "FREQ=MONTHLY;BYSETPOS=-1"
-        # expect { Rule.from_ical(str) }.to raise_error(ArgumentError, "BYSETPOS must be used in conjuction with another BY* rule part")
-
         let(:ical_str) { "RRULE:FREQ=MONTHLY;BYSETPOS=-1" }
         it_behaves_like "an invalid ical string"
       end


### PR DESCRIPTION
Adds a validation to ensure that BYSETPOS is used in conjunction with another BY* part rule

in [rfc5545](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.5), it says of the BYSETPOS rule part :

> It MUST only be used in conjunction with another BYxxx rule part.
